### PR TITLE
fixed rubocop spec helper to enable tests

### DIFF
--- a/spec/lint/rubocop_spec.rb
+++ b/spec/lint/rubocop_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'rubocop analysis' do
   it 'has no offenses' do


### PR DESCRIPTION
Fixed rubocop spec helper after getting this error: 
```
An error occurred while loading ./spec/lint/rubocop_spec.rb.
Failure/Error: require 'spec_helper'

LoadError:
  cannot load such file -- spec_helper
```
This fixed the problem and now the spec tests can run.